### PR TITLE
Use ff-oracle-jre-installer to install JRE

### DIFF
--- a/firefox.sh
+++ b/firefox.sh
@@ -6,11 +6,7 @@ mkdir -p $HOME/.mozilla/plugins
 mkdir -p $HOME/.flatpak_extras/firefox
 
 if [ ! -f $HOME/.mozilla/plugins/$JRE_PLUGIN_FILENAME ]; then
-	wget --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u112-b15/jre-8u112-linux-x64.tar.gz"
-	tar zxf jre-8u112-linux-x64.tar.gz
-	cp -r jre1.8.0_112/{bin,lib,man,plugin} $HOME/.flatpak_extras/firefox
-	ln -s $HOME/.flatpak_extras/firefox/lib/amd64/libnpjp2.so $HOME/.mozilla/plugins/$JRE_PLUGIN_FILENAME
-	rm -rf jre1.8.0_112 jre-8u112-linux.x64.tar-gz
+	ff-oracle-jre-installer &
 fi
 
 export PATH="$HOME/.flatpak_extras/firefox/bin:$PATH"

--- a/org.mozilla.firefox.json
+++ b/org.mozilla.firefox.json
@@ -135,20 +135,6 @@
       ]
     },
     {
-      "name": "wget",
-      "config-opts": [
-        "--enable-nls",
-        "--with-ssl=openssl"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://ftp.gnu.org/gnu/wget/wget-1.18.tar.xz",
-          "sha256": "b5b55b75726c04c06fe253daec9329a6f1a3c0c1878e3ea76ebfebc139ea9cc1"
-        }
-      ]
-    },
-    {
       "name": "plugins",
       "no-autogen": true,
       "sources": [
@@ -164,6 +150,111 @@
           "type": "file",
           "path": "plugins-Makefile",
           "dest-filename": "Makefile"
+        }
+      ]
+    },
+    {
+      "name": "setuptools",
+      "no-autogen": true,
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/pypa/setuptools",
+          "branch": "v33.0.0"
+        },
+        {
+          "type": "file",
+          "path": "setuptools-Makefile",
+          "dest-filename": "Makefile"
+        }
+      ]
+    },
+    {
+      "name": "setuptools-scm",
+      "no-autogen": true,
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/pypa/setuptools_scm",
+          "branch": "1.15.0"
+        },
+        {
+          "type": "file",
+          "path": "setuptools-scm-Makefile",
+          "dest-filename": "Makefile"
+        }
+      ]
+    },
+    {
+      "name": "pytest-runner",
+      "no-autogen": true,
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/pytest-dev/pytest-runner",
+          "branch": "2.10.1"
+        },
+        {
+          "type": "file",
+          "path": "python-modules-Makefile",
+          "dest-filename": "Makefile"
+        }
+      ]
+    },
+    {
+      "name": "six",
+      "no-autogen": true,
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/benjaminp/six"
+        },
+        {
+          "type": "file",
+          "path": "python-modules-Makefile",
+          "dest-filename": "Makefile"
+        }
+      ]
+    },
+    {
+      "name": "python-utils",
+      "no-autogen": true,
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/WoLpH/python-utils/archive/v2.0.1.tar.gz",
+          "sha256": "615bf41699b84bf231ad644e00101610f94182aed9170926cebbbff7ebdfec2e"
+        },
+        {
+          "type": "file",
+          "path": "python-modules-Makefile",
+          "dest-filename": "Makefile"
+
+        }
+      ]
+    },
+    {
+      "name": "python-progressbar",
+      "no-autogen": true,
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/WoLpH/python-progressbar/archive/v3.12.0.tar.gz",
+          "sha256": "13561586ee64d68816779f2d938768d46350237d10058d18a32db1ad260bf465"
+        },
+        {
+          "type": "file",
+          "path": "python-modules-Makefile",
+          "dest-filename": "Makefile"
+        }
+      ]
+    },
+    {
+      "name": "installer",
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/kinvolk/firefox-flatpak-oracle-jre-installer"
         }
       ]
     }

--- a/python-modules-Makefile
+++ b/python-modules-Makefile
@@ -1,0 +1,9 @@
+.PHONY: all test
+
+all:
+	true
+
+test: all
+
+install:
+	python3 setup.py install --prefix=/app

--- a/setuptools-Makefile
+++ b/setuptools-Makefile
@@ -1,0 +1,10 @@
+.PHONY: all test
+
+all:
+	true
+
+test: all
+
+install:
+	python3 bootstrap.py
+	python3 setup.py install --prefix=/app

--- a/setuptools-scm-Makefile
+++ b/setuptools-scm-Makefile
@@ -1,0 +1,10 @@
+.PHONY: all test
+
+all:
+	true
+
+test: all
+
+install:
+	python3 setup.py egg_info
+	python3 setup.py install --prefix=/app


### PR DESCRIPTION
This new utility was written to install JRE and provide a feedback to user when installation is complete.

That's the continuation of the approach of installing JRE on flatpak run phase, due to the custom cookie we haveto provide in order to download JRE from Oracle. Unfortunately, Flatpak's extra_data functionality isn't able to use custom cookies.

---

Please don't merge it before https://github.com/kinvolk/firefox-flatpak-oracle-jre-installer/pull/1