### PR TITLE
Switch to the Endless OS runtime

### DIFF
--- a/libvpx-max_align_t.patch
+++ b/libvpx-max_align_t.patch
@@ -1,0 +1,17 @@
+--- a/nestegg/halloc/src/align.h
++++ b/nestegg/halloc/src/align.h
+@@ -15,6 +15,8 @@
+ #ifndef _LIBP_ALIGN_H_
+ #define _LIBP_ALIGN_H_
+ 
++#ifndef _GCC_MAX_ALIGN_T
++
+ /*
+  *	a type with the most strict alignment requirements
+  */
+@@ -34,3 +36,5 @@
+ 
+ #endif
+ 
++#endif
++

--- a/org.mozilla.firefox.json
+++ b/org.mozilla.firefox.json
@@ -1,8 +1,8 @@
 {
   "app-id": "org.mozilla.firefox",
-  "runtime": "org.gnome.Platform",
-  "runtime-version": "3.22",
-  "sdk": "org.gnome.Sdk",
+  "runtime": "com.endlessm.Platform",
+  "runtime-version": "eos3.1",
+  "sdk": "com.endlessm.Sdk",
   "branch": "50.1.0",
   "command": "firefox-wrapper",
   "separate-locales": false,
@@ -26,6 +26,20 @@
           "type": "archive",
           "url": "http://ftp.gnu.org/gnu/autoconf/autoconf-2.13.tar.gz",
           "sha256": "f0611136bee505811e9ca11ca7ac188ef5323a8e2ef19cffd3edb3cf08fd791e"
+        }
+      ]
+    },
+    {
+      "name": "dbus-glib",
+      "config-opts": [
+        "--enable-static=no",
+        "--enable-bash-completion=no"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.108.tar.gz",
+          "sha256": "9f340c7e2352e9cdf113893ca77ca9075d9f8d5e81476bf2bf361099383c602c"
         }
       ]
     },
@@ -68,7 +82,9 @@
         "--enable-vp9",
         "--enable-vp9-highbitdepth",
         "--enable-experimental",
-        "--enable-spatial-svc"
+        "--enable-spatial-svc",
+        "--enable-install-srcs",
+        "--enable-codec-srcs"
       ],
       "sources": [
         {
@@ -101,6 +117,163 @@
           "type": "archive",
           "url": "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-1.10.2.tar.xz",
           "sha256": "fbc0d40fcb746d2efe2ea47444674029912f66e6107f232766d33b722b97de20"
+        }
+      ]
+    },
+    {
+      "name": "unzip",
+      "no-autogen": true,
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://netassist.dl.sourceforge.net/project/infozip/UnZip%206.x%20%28latest%29/UnZip%206.0/unzip60.tar.gz",
+          "sha256": "036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37"
+        },
+        {
+          "type": "patch",
+          "path": "unzip.patch"
+        },
+        {
+          "type": "file",
+          "path": "unzip-Makefile",
+          "dest-filename": "Makefile"
+        }
+      ]
+    },
+    {
+      "name": "zip",
+      "no-autogen": true,
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://heanet.dl.sourceforge.net/project/infozip/Zip%203.x%20%28latest%29/3.0/zip30.tar.gz",
+          "sha256": "f0e8bb1f9b7eb0b01285495a2699df3a4b766784c1765a8f1aeedf63c0806369"
+        },
+        {
+          "type": "patch",
+          "path": "zip.patch"
+        },
+        {
+          "type": "file",
+          "path": "unzip-Makefile",
+          "dest-filename": "Makefile"
+        }
+      ]
+    },
+    {
+      "name": "alsa-lib",
+      "config-opts": [
+        "--disable-maintainer-mode",
+        "--enable-shared",
+        "--disable-resmgr",
+        "--enable-rawmidi",
+        "--enable-seq",
+        "--enable-aload"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://ftp.osuosl.org/pub/blfs/conglomeration/alsa-lib/alsa-lib-1.1.2.tar.bz2",
+          "sha256": "d38dacd9892b06b8bff04923c380b38fb2e379ee5538935ff37e45b395d861d6"
+        }
+      ]
+    },
+    {
+      "name": "json-c",
+      "config-opts": [
+        "--prefix=/app",
+        "--disable-static"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://s3.amazonaws.com/json-c_releases/releases/json-c-0.12.1.tar.gz",
+          "sha256": "2a136451a7932d80b7d197b10441e26e39428d67b1443ec43bbba824705e1123"
+        }
+      ]
+    },
+    {
+      "name": "libogg",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.xz",
+          "sha256": "3f687ccdd5ac8b52d76328fbbfebc70c459a40ea891dbf3dccb74a210826e79b"
+        }
+      ]
+    },
+    {
+      "name": "flac",
+      "config-opts": [
+        "--disable-sse",
+        "--disable-doxygen-docs",
+        "--disable-xmms-plugin",
+        "--disable-examples"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://downloads.xiph.org/releases/flac/flac-1.3.1.tar.xz",
+          "sha256": "4773c0099dba767d963fd92143263be338c48702172e8754b9bc5103efe1c56c"
+        }
+      ]
+    },
+    {
+      "name": "libvorbis",
+      "config-opts": [
+        "--disable-static"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.xz",
+          "sha256": "54f94a9527ff0a88477be0a71c0bab09a4c3febe0ed878b24824906cd4b0e1d1"
+        }
+      ]
+    },
+    {
+      "name": "libsndfile",
+      "config-opts": [
+        "--prefix=/app",
+        "--disable-sqlite"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.27.tar.gz",
+          "sha256": "a391952f27f4a92ceb2b4c06493ac107896ed6c76be9a613a4731f076d30fac0"
+        }
+      ]
+    },
+    {
+      "name": "tdb",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://www.samba.org/ftp/tdb/tdb-1.3.12.tar.gz",
+          "sha256": "60134e32253cac8e2efe5e0185d20123c208bcf6ad15edf2f50d80daadf8c348"
+        }
+      ]
+    },
+    {
+      "name": "pulseaudio",
+      "config-opts": [
+        "--prefix=/app",
+        "--libexecdir=/app/lib",
+        "--with-udev-rules-dir=/app/lib/udev/rules.d",
+        "--with-database=tdb",
+        "--disable-tcpwrap",
+        "--disable-bluez4",
+        "--disable-samplerate",
+        "--disable-rpath",
+        "--disable-default-build-tests",
+        "--without-caps"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://freedesktop.org/software/pulseaudio/releases/pulseaudio-9.0.tar.xz",
+          "sha256": "c3d3d66b827f18fbe903fe3df647013f09fc1e2191c035be1ee2d82a9e404686"
         }
       ]
     },

--- a/setuptools-Makefile
+++ b/setuptools-Makefile
@@ -6,5 +6,6 @@ all:
 test: all
 
 install:
+	mkdir -p /app/lib/python3.4/site-packages/
 	python3 bootstrap.py
 	python3 setup.py install --prefix=/app

--- a/setuptools.patch
+++ b/setuptools.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.cfg b/setup.cfg
+index 1d45057..f77345a 100755
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -24,3 +24,7 @@ universal = 1
+ 
+ [bumpversion:file:setup.py]
+ 
++[install]
++prefix=/app
++install_lib=/app/lib/python3.4/dist-packages
++install_scripts=/app/bin

--- a/unzip-Makefile
+++ b/unzip-Makefile
@@ -1,0 +1,5 @@
+all:
+	make -f unix/Makefile generic
+
+install:
+	make -f unix/Makefile install

--- a/unzip.patch
+++ b/unzip.patch
@@ -1,0 +1,11 @@
+--- a/unix/Makefile
++++ b/unix/Makefile
+@@ -121,7 +121,7 @@
+ INSTALL_D = mkdir -p
+ # on some systems, manext=l and MANDIR=/usr/man/man$(manext) may be appropriate
+ manext = 1
+-prefix = /usr/local
++prefix = /app
+ BINDIR = $(prefix)/bin#			where to install executables
+ MANDIR = $(prefix)/man/man$(manext)#	where to install man pages
+ INSTALLEDBIN = $(BINDIR)/funzip$E $(BINDIR)/unzip$E $(BINDIR)/unzipsfx$E \

--- a/zip.patch
+++ b/zip.patch
@@ -1,0 +1,11 @@
+--- a/unix/Makefile
++++ b/unix/Makefile
+@@ -38,7 +38,7 @@
+ MANFLAGS = 644
+ 
+ # target directories - where to install executables and man pages to
+-prefix = /usr/local
++prefix = /app
+ BINDIR = $(prefix)/bin
+ MANEXT=1
+ MANDIR = $(prefix)/man/man$(MANEXT)


### PR DESCRIPTION
This commit changes the runtime from Gnome to Endless.

The following packages were needed to be added to the flatpak
manifest:
- json-c
- libogg
- flac
- libvorbis
- libsndfile
- tdb
- pulseaudio